### PR TITLE
Separación de credenciales y fase de inicialización de DB

### DIFF
--- a/Deploy/site-cookbooks/urbem/attributes/default.rb
+++ b/Deploy/site-cookbooks/urbem/attributes/default.rb
@@ -1,1 +1,1 @@
-default["urbem"]["branch"] = "master"
+default["urbem"]["branch"] = "staging-puebla"

--- a/Deploy/site-cookbooks/urbem/attributes/default.rb
+++ b/Deploy/site-cookbooks/urbem/attributes/default.rb
@@ -1,1 +1,1 @@
-default["urbem"]["branch"] = "staging-puebla"
+default["urbem"]["branch"] = "master"

--- a/Deploy/site-cookbooks/urbem/libraries/creds_helper.rb
+++ b/Deploy/site-cookbooks/urbem/libraries/creds_helper.rb
@@ -1,0 +1,49 @@
+module Creds
+  module Helper
+
+    def creds_h
+      if node["key_file"]
+        secret = Chef::EncryptedDataBagItem.load_secrets("#{node['key_file']['path']}")
+        creds = Chef::EncryptedDataBagItem.load("urbem", "keys", secret)
+      else
+        creds = data_bag_item('keys', 'secret')
+      end
+
+      creds
+    end
+
+    def list_creds
+        creds = creds_h
+
+        list_creds = [
+          "MAILER_FROM=#{creds['email']}",
+          "FACEBOOK_SECRET=#{creds['facebook']['secret']}",
+          "FACEBOOK_KEY=#{creds['facebook']['key']}",
+          "TWITTER_KEY=#{creds['twitter']['key']}",
+          "TWITTER_SECRET=#{creds['twitter']['secret']}",
+          "TWITTER_OAUTH_TOKEN=#{creds['twitter']['oauth_token']}",
+          "TWITTER_OAUTH_TOKEN_SECRET=#{creds['twitter']['oauth_token_secret']}",
+          "SENDGRID_USERNAME=#{creds['sendgrid']['username']}",
+          "SENDGRID_PASSWORD=#{creds['sendgrid']['password']}",
+          "COVERALLS_TOKEN=#{creds['coverall_token']}",
+          "SECRET_KEY_BASE=#{creds['rails']['secret_key_base']}",
+          "RAILS_ENV=#{creds['rails']['env']}",
+          "PASSENGER_APP_ENV=#{creds['rails']['env']}",
+          "POSTGRES_PASSWORD=#{creds['postgres']['password']}",
+          "S3_BUCKET=#{creds['aws']['s3_bucket_name']}",
+          "AWS_SECRET=#{creds['aws']['aws_secret']}",
+          "AWS_KEY=#{creds['aws']['aws_key']}"
+        ]
+
+        list_creds.push "APP_NAME=#{if creds['app_name'] then  creds['app_name'] else "urbem" end}"
+        list_creds.push "HOST=#{if creds['host'] then  creds['host'] else "urbem:80" end}"
+
+        list_creds
+    end
+
+    def postgres_pwd
+      creds = creds_h
+      creds['postgres']['password']
+    end
+  end
+end

--- a/Deploy/site-cookbooks/urbem/recipes/default.rb
+++ b/Deploy/site-cookbooks/urbem/recipes/default.rb
@@ -79,14 +79,21 @@ docker_container "redis" do
 end
 
 
-directory "/var/urbem/" do
+directory "/www" do
+  owner "root"
+  group "root"
+  mode "755"
+  action :create
+end
+
+directory "/www/sitios/" do
   owner "root"
   group "root"
   mode  "755"
   action :create
 end
 
-git "/var/urbem" do
+git "/www/sitios/EvaluatuTramite" do
   revision node["urbem"]["branch"]
   repository "https://github.com/civica-digital/urbem-puebla.git"
   notifies :run, "docker_container[commit_db]", :immediately
@@ -112,7 +119,7 @@ end
 
 docker_image 'urbem-puebla' do
   tag 'latest'
-  source "/var/urbem"
+  source "/www/sitios/EvaluatuTramite"
   begin
      Docker::Image.get("urbem-puebla")
      action :nothing

--- a/Deploy/site-cookbooks/urbem/recipes/default.rb
+++ b/Deploy/site-cookbooks/urbem/recipes/default.rb
@@ -145,7 +145,7 @@ docker_container 'urbem_migrate' do
   remove_automatically true
   env  list_creds
   action :nothing
-  notifies :run, "docker_container[urbem]", :immediately
+  notifies :redeploy, "docker_container[urbem]", :immediately
   cmd_timeout 1000
 end
 

--- a/Deploy/site-cookbooks/urbem/recipes/inicializar_db.rb
+++ b/Deploy/site-cookbooks/urbem/recipes/inicializar_db.rb
@@ -1,0 +1,13 @@
+Chef::Resource::DockerContainer.send(:include, Creds::Helper)
+
+docker_container 'setup_migrate' do
+  image "urbem-puebla"
+  entrypoint "rake"
+  command "db:setup"
+  link ["postgres:postgres", "redis:redis"]
+  container_name "setup_dbs"
+  remove_automatically true
+  env  list_creds
+  action :nothing
+  cmd_timeout 1000
+end


### PR DESCRIPTION
Permite obtener las configuraciones a través de un Helper definido libraries. 
Esto permite compartir las configuraciones entre múltiples recetas evitando la duplicación de código.
Separa la creación inicial de datos en una receta, debido a que puede borrar los datos de la DB.
