### PR TITLE
hotfix: Se agrega cast a to_f para que los casos NIL sumen 0.0 en reportes

### DIFF
--- a/app/services/reports.rb
+++ b/app/services/reports.rb
@@ -59,7 +59,7 @@ module Reports
 
     def total_by_area(areas_hash_array, key, acc)
       return acc if areas_hash_array.empty?
-      next_value = areas_hash_array.shift[key]
+      next_value = areas_hash_array.shift[key].to_f
       total_by_area(areas_hash_array, key, acc + next_value)
     end
 


### PR DESCRIPTION
Se agrega permisividad en la suma de reportes de reportes. 
Se permite que si un reporte no tiene un valor agregue 0 a la suma acumulada de puntajes.
