### PR TITLE
Se agrega /storage al gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 /config/env_variables.yml
 /public/uploads/*
 *.dump
+/storage
 
 # Ignore application configuration
 /config/application.yml


### PR DESCRIPTION
 porque ahi se guardan archivos de aplicacion
