### PR TITLE
Skip build

### DIFF
--- a/Deploy/site-cookbooks/urbem/recipes/default.rb
+++ b/Deploy/site-cookbooks/urbem/recipes/default.rb
@@ -186,7 +186,7 @@ docker_container "urbem" do
   container_name "urbem"
   link ["postgres:postgres", "redis:redis"]
   env  list_creds
-  volume ['/www/sitios/storage:/home/app/urbem/storage:rw', '/www/sitios/EvaluatuTramite:/home/app/urbem']
+  volume ['/www/sitios/EvaluatuTramite:/home/app/urbem', '/www/sitios/storage:/home/app/urbem/storage:rw']
   detach true
   port ['80:80', "443:443"]
   notifies :redeploy, "docker_container[sidekiq]", :immediately
@@ -198,7 +198,7 @@ docker_container "sidekiq" do
   image "urbem-puebla"
   container_name "sidekiq"
   link ["postgres:postgres", "redis:redis"]
-  volume ['/www/sitios/storage:/home/app/urbem/storage:rw', '/www/sitios/EvaluatuTramite:/home/app/urbem']
+  volume ['/www/sitios/EvaluatuTramite:/home/app/urbem', '/www/sitios/storage:/home/app/urbem/storage:rw']
   env list_creds
   detach true
   entrypoint "sidekiq"

--- a/Deploy/site-cookbooks/urbem/recipes/default.rb
+++ b/Deploy/site-cookbooks/urbem/recipes/default.rb
@@ -141,14 +141,14 @@ docker_container "commit_db" do
   container_name "backup_db"
   ignore_failure true
   action :nothing
-  notifies :build,  "docker_image[urbem-puebla]", :immediately
+  notifies :build,  "docker_image[urbem_create]", :immediately
   cmd_timeout 600
 end
 
 docker_image 'urbem-puebla' do
   tag 'latest'
   source "/www/sitios/EvaluatuTramite"
-  action :build
+  action :nothing
   notifies :run, 'docker_container[urbem_create]', :immediately
   cmd_timeout 2400
 end
@@ -161,8 +161,9 @@ docker_container 'urbem_create' do
   link ["postgres:postgres", "redis:redis"]
   remove_automatically true
   env list_creds
-  action :nothing
+  action :run
   notifies :run, "docker_container[urbem_migrate]", :immediately
+  volume [ '/www/sitios/EvaluatuTramite:/home/app/urbem']
   cmd_timeout 1000
 end
 
@@ -174,6 +175,7 @@ docker_container 'urbem_migrate' do
   container_name "migrate_dbs"
   remove_automatically true
   env  list_creds
+  volume [ '/www/sitios/EvaluatuTramite:/home/app/urbem']
   action :nothing
   notifies :redeploy, "docker_container[urbem]", :immediately
   cmd_timeout 1000
@@ -184,7 +186,7 @@ docker_container "urbem" do
   container_name "urbem"
   link ["postgres:postgres", "redis:redis"]
   env  list_creds
-  volume '/www/sitios/storage:/home/app/urbem/storage:rw'
+  volume ['/www/sitios/storage:/home/app/urbem/storage:rw', '/www/sitios/EvaluatuTramite:/home/app/urbem']
   detach true
   port ['80:80', "443:443"]
   notifies :redeploy, "docker_container[sidekiq]", :immediately
@@ -196,6 +198,7 @@ docker_container "sidekiq" do
   image "urbem-puebla"
   container_name "sidekiq"
   link ["postgres:postgres", "redis:redis"]
+  volume ['/www/sitios/storage:/home/app/urbem/storage:rw', '/www/sitios/EvaluatuTramite:/home/app/urbem']
   env list_creds
   detach true
   entrypoint "sidekiq"


### PR DESCRIPTION
Evita la instalación de gems usando una imagen pre-construida y usando el repositorio como bind.
