### PR TITLE
Se cambia directorio root de carrierwave

### DIFF
--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -8,7 +8,7 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    "storage/uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -7,7 +7,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    "storage/uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
   version :comment do

--- a/app/uploaders/logo_uploader.rb
+++ b/app/uploaders/logo_uploader.rb
@@ -5,7 +5,7 @@ class LogoUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
   def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    "storage/uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
   version :footer_thumb do

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,5 +1,5 @@
 CarrierWave.configure do |config|
-  config.fog_directory      = Rails.root.join('public/storage')
+  config.fog_directory      = Rails.root.join('public')
   config.permissions = 0666
   config.directory_permissions = 0777
   config.storage(:file)


### PR DESCRIPTION
Se cambia el directorio Root de carrierwave y se cambia también la ruta donde se guardan las imágenes en los uploaders.
