### PR TITLE
Dar de alta observador desde alta de servidor publico

### DIFF
--- a/app/controllers/admins/public_servants_controller.rb
+++ b/app/controllers/admins/public_servants_controller.rb
@@ -75,7 +75,7 @@ class Admins::PublicServantsController < ApplicationController
 
     params
       .require(:admin)
-      .permit(:name, :email, :record_number, :dependency, :administrative_unit, :charge, :surname, :second_surname)
+      .permit(:name, :email, :record_number, :dependency, :administrative_unit, :charge, :surname, :second_surname, :is_observer)
       .merge(services: services, is_public_servant: true)
   end
 

--- a/app/views/admins/public_servants/new.html.erb
+++ b/app/views/admins/public_servants/new.html.erb
@@ -74,6 +74,14 @@
           </div>
         </div>
       </fieldset>
+      <fieldset>
+        <div class="form-group">
+          <%= f.label :is_observer, t('form.labels.is_observer'), class: 'col-md-2 control-label' %>
+          <div class="col-md-5 checkbox">
+            <%= f.check_box :is_observer, class: '' %>
+          </div>
+        </div>
+      </fieldset>
       <div class="actions col-md-2">
         <%= f.submit "Guardar", class: 'btn btn-primary' %>
       </div>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -646,6 +646,7 @@ es:
       address: "Dirección"
       description: "Descripción*"
       service: "Trámites*"
+      is_observer: "¿Es observador?"
       admin:
         service: "Trámites"
         who: "¿Quién lo atendió?"


### PR DESCRIPTION
Ahora se puede dar de alta un observador desde la forma de alta de servidores públicos.
