### PR TITLE
Fix de visualización en  reportes en ie11

### DIFF
--- a/app/controllers/service_survey_reports_controller.rb
+++ b/app/controllers/service_survey_reports_controller.rb
@@ -2,7 +2,6 @@ class ServiceSurveyReportsController < ApplicationController
 
   before_action :set_reports_for_index, :only => :index
 
-     layout 'observers'
 
   def index
     @service_surveys_reports = set_reports_for_index

--- a/app/views/admins/service_surveys/index.html.erb
+++ b/app/views/admins/service_surveys/index.html.erb
@@ -45,8 +45,9 @@
                       <%= f.submit t('service_report.new'), class: 'hidden' %>
                   <% end %>
 
+                  <li><%= link_to t('service_report.go_to_index'), service_survey_reports_path(service_survey_id: survey.id),"target"=> "_blank" %></li>
                   <li><%= link_to t('service_report.new'), "#", class: "js-generate-report", "data-submit" => "#new-report-#{survey.id}" %></li>
-                  <li><%= link_to t('service_report.go_to_index'), service_survey_reports_path(service_survey_id: survey.id) %></li>
+
                 </ul>
               </div>
 


### PR DESCRIPTION
La pantalla del reporte se cortaba y se arregló.
