### PR TITLE
Mejoras de seguridad Nginx

### DIFF
--- a/docker/urbem.conf
+++ b/docker/urbem.conf
@@ -2,6 +2,16 @@ server {
     access_log /dev/stdout;
     error_log /dev/stderr;
 
+    rewrite_by_lua '
+      ngx.header.server = nil
+      ngx.header["X-Powered-By"] = nil
+    ';
+
+    header_filter_by_lua '
+        ngx.header.server = nil
+        ngx.header["X-Powered-By"] = nil
+    ';
+
     listen 80;
     server_name evaluatutramitepruebas.puebla.gob.mx;
     root /home/app/urbem/public;
@@ -15,6 +25,7 @@ server {
     passenger_ruby /usr/bin/ruby2.2;
 }
 server{
+    listen 80  default_server;
     listen 443 default_server;
     return 444;
 }


### PR DESCRIPTION
Se agrega rewrite de headers que dan información sobre entorno del servidor y ya no se puede acceder al server por ip, se puso un server default para devolver respuestas en blanco. Solo se puede acceder por nombre de dominio.
