### PR TITLE
Bugfix respuesta anterior

### DIFF
--- a/app/assets/javascripts/service_survey.js.coffee
+++ b/app/assets/javascripts/service_survey.js.coffee
@@ -1,6 +1,7 @@
 $ ->
   # Este watcher se usa en vista de admin
-  # de service_surveys
+  # de service_surveys y sirve para generar reportes
+  # con una forma oculta.
 
   $(".js-generate-report").click  ->
     submit_object = $(this).data('submit')

--- a/app/assets/javascripts/survey_answers.js.coffee
+++ b/app/assets/javascripts/survey_answers.js.coffee
@@ -28,7 +28,7 @@ $(document).on 'click', '.js-question-item', ->
 
   $(element).val(questionText)
   $(element).parent().closest(".js-question").find(".js-answer-selection option[value='" + answerType + "']").attr('selected', 'selected')
-  showAnswerType(this, answerType)
+  showAnswerType($(element).parent().closest(".js-question"), answerType)
 
 showAnswerType = (element, answerType) ->
   if answerType == 'binary' || answerType == 'rating'


### PR DESCRIPTION
Bugfix, cuando creas una encuesta y eliges una respuesta anteriormente usada no se mostraba el campo de valor ni el tipo de respuesta a mostrar, en caso de que fuera binaria o de rango.
