### PR TITLE
Removes "Centro de atención" from services input prompt

### DIFF
--- a/app/views/admins/service_admins/edit.html.haml
+++ b/app/views/admins/service_admins/edit.html.haml
@@ -59,7 +59,7 @@
             %h3
               = t(".services_to_assign")
             .col-md-5
-              = f.select :services_ids, @services.collect {|p| [p.name, p.id]}, { prompt: t('service_requests.form.prompt_center') }, { class: 'js-load_service_fields chosen-select',:multiple=>true }
+              = f.select :services_ids, @services.collect {|p| [p.name, p.id]}, {}, { class: 'js-load_service_fields chosen-select',:multiple=>true }
         .actions.col-md-2
           = f.submit t(".update"), class: 'btn btn-primary'
 


### PR DESCRIPTION
As #145651651 if you see 'Centro de atención' in a services input, can be annoying. Fixed!